### PR TITLE
Use charts from the master branch in docs

### DIFF
--- a/docs/en/Octopod_deployment_guide.md
+++ b/docs/en/Octopod_deployment_guide.md
@@ -79,7 +79,7 @@ To function properly _Octopod_ needs to generate three TLS certificates for the 
 To download the source code required to install _Octopod Sever_ you will need to clone the git repository:
 
 ```bash
-git clone https://github.com/typeable/octopod.git /tmp/octopod
+git clone --branch master https://github.com/typeable/octopod.git /tmp/octopod
 ```
 
 ## Creating required namespaces

--- a/docs/ru/Octopod_deployment_with_K8S.md
+++ b/docs/ru/Octopod_deployment_with_K8S.md
@@ -39,7 +39,7 @@
 4. Скачивание исходного кода проекта
 
    ```bash
-   git clone https://github.com/typeable/octopod.git /tmp/octopod
+   git clone --branch master https://github.com/typeable/octopod.git /tmp/octopod
    ```
 
 5. Создание namespace `deployment` и `octopod`


### PR DESCRIPTION
Updated docs: will use charts from the master branch to deploy octopod.