### PR TITLE
Set search box width

### DIFF
--- a/octopod-frontend/src/Page/Deployments.hs
+++ b/octopod-frontend/src/Page/Deployments.hs
@@ -113,6 +113,7 @@ deploymentsHeadWidget enabledSearch okUpdEv =
           (  "type" =: "text"
           <> "class" =: "input__widget"
           <> "placeholder" =: "Search for deployments"
+          <> "style" =: "width: 264px;"
           <> enabledSearchAttr)
         & inputElementConfig_setValue .~ ("" <$ domEvent Click deleteEl)
       (deleteEl, _) <- elClass' "button" "input__clear-type spot spot--cancel" $


### PR DESCRIPTION
There is an issue in Chrome that the width of the search box is smaller than in other browsers. As far as I was able to understand it, the width is not specified anywhere explicitly and it is set to the default size of the text field. 

I just added an explicit width style.

### Before
![Screenshot 2021-01-15 at 20 15 20](https://user-images.githubusercontent.com/6209627/104758161-10d03900-576f-11eb-8d79-3f98962117da.png)

### After

![Screenshot 2021-01-15 at 20 15 35](https://user-images.githubusercontent.com/6209627/104758166-1463c000-576f-11eb-81f4-c01d5ca1e969.png)
