### PR TITLE
Added fuzzy search to Web UI

### DIFF
--- a/octopod-frontend/octopod-frontend.cabal
+++ b/octopod-frontend/octopod-frontend.cabal
@@ -35,6 +35,7 @@ executable frontend
                      , Servant.Reflex.Extra
                      , Page.Elements.Links
                      , Reflex.MultiEventWriter.Class
+                     , Data.Text.Search
   ghc-options:         -Wall
                        -Werror
                        -Wno-missing-home-modules

--- a/octopod-frontend/src/Data/Text/Search.hs
+++ b/octopod-frontend/src/Data/Text/Search.hs
@@ -1,0 +1,47 @@
+module Data.Text.Search
+  ( fuzzySearch
+  , FuzzySearchStringChunk(..)
+  ) where
+
+import           Control.Applicative
+import           Data.Bifunctor
+import           Data.Char
+import           Data.Function
+import           Data.List
+import           Data.Text (Text)
+import qualified Data.Text as T
+
+type Needle = Text
+type Haystack = Text
+type Running = Int
+type Penalty = Int
+
+fuzzySearch' :: Needle -> Haystack -> Running -> Penalty -> [([FuzzySearchStringChunk String], Int)]
+fuzzySearch' needle haystack i p = case (T.uncons needle, T.uncons haystack) of
+  (Just _, Nothing) -> []
+  (Just (n, eedle), Just (h, aystack)) ->
+    bimap (prependNotMatched h)  (+ (i - p)) <$> fuzzySearch' needle aystack 0 p
+    <|> if toLower n == toLower h
+      then first (prependMatched h) <$> fuzzySearch' eedle aystack (i * 2 + 1) 1
+      else empty
+  (Nothing, Nothing) -> [([], i)]
+  (Nothing, Just _) -> [([NotMatched $ T.unpack haystack], i)]
+
+prependMatched :: Char -> [FuzzySearchStringChunk String] -> [FuzzySearchStringChunk String]
+prependMatched c xs@(NotMatched _ : _) = Matched [c] : xs
+prependMatched c (Matched cs : xs) = Matched (c : cs) : xs
+prependMatched c [] = [Matched [c]]
+
+prependNotMatched :: Char -> [FuzzySearchStringChunk String] -> [FuzzySearchStringChunk String]
+prependNotMatched c xs@(Matched _ : _) = NotMatched [c] : xs
+prependNotMatched c (NotMatched cs : xs) = NotMatched (c : cs) : xs
+prependNotMatched c [] = [NotMatched [c]]
+
+fuzzySearch :: Needle -> Haystack -> Maybe ([FuzzySearchStringChunk Text], Int)
+fuzzySearch "" h = Just ([NotMatched h], 0)
+fuzzySearch n h = case fuzzySearch' n h 0 0 of
+  [] -> Nothing
+  xs@(_:_) -> Just . (first . fmap . fmap) T.pack $ maximumBy (compare `on` snd) xs
+
+data FuzzySearchStringChunk a = NotMatched !a | Matched !a
+  deriving (Show, Eq, Functor)


### PR DESCRIPTION
The added fuzzy search has the following properties:
- the closer the match is to a substring, the higher score it gets (any non-substring matches will always get a lower score than a substring match)
- When searching the deployments are sorted in order of the search score
- after searching it is possible to change the sorting by clicking on one of the sortable headers. (searching again will reset the sorting.)
- deployment names and deployment tags are treated equally
- The matched part of the deployment is underlined.


https://user-images.githubusercontent.com/6209627/105076010-9586c400-5a9b-11eb-90bd-a0a6a56c8f66.mov


