### PR TITLE
Made three dots clickable when deployment is creating

### DIFF
--- a/octopod-frontend/src/Page/Deployments.hs
+++ b/octopod-frontend/src/Page/Deployments.hs
@@ -295,18 +295,15 @@ activeDeploymentWidget clickedEv dDyn' = do
         text $ formatPosixToDate updatedAt
       el "td" $ do
         let
-          disabledAttr = if isPending status
-            then "disabled" =: ""
-            else mempty
+          enabled = not $ isPending status
           elId = "deployment_row_" <> unDeploymentName dName
           btn = elAttr "button"
             (  "class" =: "drop__handler"
             <> "type" =: "button"
-            <> "id" =: elId
-            <> disabledAttr) $ text "Actions"
+            <> "id" =: elId ) $ text "Actions"
           body = do
-            btnEditEv <- buttonClass "action action--edit" "Edit"
-            btnArcEv <- buttonClass "action action--archive" "Move to archive"
+            btnEditEv <- buttonClassEnabled' "action action--edit" "Edit" (pure enabled) "action--disabled"
+            btnArcEv <- buttonClassEnabled' "action action--archive" "Move to archive" (pure enabled) "action--disabled"
             url' <- kubeDashboardUrl (view #deployment <$> dDyn)
             void . dyn $ url' <&> maybe blank (\url ->
               void $ aButtonClass' "action action--logs" "Details"


### PR DESCRIPTION
Moved the status inside the menu. It now impacts individual menu elements instead of the tree dots.

### Before

https://user-images.githubusercontent.com/6209627/106606594-5ebcad80-6573-11eb-9f21-eb17a89f32d8.mov

### After 


https://user-images.githubusercontent.com/6209627/106606610-62e8cb00-6573-11eb-8d13-afd58e9998ec.mov

