### PR TITLE
Use PostgreSQL 12 version

### DIFF
--- a/charts/octopod-infra/templates/postgres-statefulset.yaml
+++ b/charts/octopod-infra/templates/postgres-statefulset.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 120
       containers:
       - name: postgres
-        image: postgres:10
+        image: postgres:12
         envFrom:
           - configMapRef:
               name: {{ .Release.Name }}-postgres-config


### PR DESCRIPTION
Migrations require PostgreSQL 12 version minimum.