### PR TITLE
Don't consider pending deployments archived

### DIFF
--- a/octopod-common/src/Common/Types.hs
+++ b/octopod-common/src/Common/Types.hs
@@ -173,7 +173,10 @@ data DeploymentFullInfo = DeploymentFullInfo
   deriving (FromJSON, ToJSON) via Snake DeploymentFullInfo
 
 isDeploymentArchived :: DeploymentFullInfo -> Bool
-isDeploymentArchived = isArchivedStatus . recordedStatus . getField @"status"
+isDeploymentArchived (DeploymentNotPending s) = isArchivedStatus s
+-- if the deployment is currently undergoing some process,
+-- then it is not considered archived
+isDeploymentArchived (DeploymentPending _) = False
 
 data DeploymentUpdate = DeploymentUpdate
   { newTag :: DeploymentTag

--- a/octopod-common/src/Common/Types.hs
+++ b/octopod-common/src/Common/Types.hs
@@ -173,10 +173,11 @@ data DeploymentFullInfo = DeploymentFullInfo
   deriving (FromJSON, ToJSON) via Snake DeploymentFullInfo
 
 isDeploymentArchived :: DeploymentFullInfo -> Bool
-isDeploymentArchived (DeploymentNotPending s) = isArchivedStatus s
--- if the deployment is currently undergoing some process,
--- then it is not considered archived
-isDeploymentArchived (DeploymentPending _) = False
+isDeploymentArchived DeploymentFullInfo {status = s} = case s of
+  DeploymentNotPending s -> isArchivedStatus s
+  -- if the deployment is currently undergoing some process,
+  -- then it is not considered archived
+  DeploymentPending _ -> False
 
 data DeploymentUpdate = DeploymentUpdate
   { newTag :: DeploymentTag


### PR DESCRIPTION
Currently restoring a staging from archived can leave it in the archived list for a while. This aims to fix this.

---

Note: due to https://github.com/reflex-frp/reflex-platform/issues/714 I am not currently able to test it myself. (Tried cherry-picking the fix commits, but it turned out to be non-trivial.). I think the PR does what I think it does.