### PR TITLE
Explicitly set postgres version to 12 for Helm 3 chart

### DIFF
--- a/charts/helm3/octopod/Chart.lock
+++ b/charts/helm3/octopod/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.4.2
-digest: sha256:616138842fd07e138b0e8d6b7dac7989942b01a94967c37ca41c94e3fe93e9e4
-generated: "2021-05-07T21:02:01.403373727+03:00"
+  version: 10.5.3
+digest: sha256:d8ba564b767cbf73a4ca87cb3b97e0a75bc813ba0a58a1b0bd6c7154a608e783
+generated: "2021-07-16T15:31:01.633560857+03:00"

--- a/charts/helm3/octopod/Chart.yaml
+++ b/charts/helm3/octopod/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: octopod
 description: An opensource self-hosted solution for managing multiple deployments in a Kubernetes cluster.
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: 1.2
 keywords:
   - kubernetes
@@ -15,6 +15,6 @@ maintainers:
     email: a.sizov@typeable.io
 dependencies:
   - name: postgresql
-    version: 10.4.2
+    version: 10.5.3
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled

--- a/charts/helm3/octopod/values.yaml
+++ b/charts/helm3/octopod/values.yaml
@@ -100,6 +100,8 @@ postgresql:
   enabled: true
   postgresqlUsername: octopod
   postgresqlDatabase: octopod
+  image:
+    tag: 12.7.0-debian-10-r51
 vault:
   enabled: false
   clusterName: ""


### PR DESCRIPTION
Migrations aren't compatible with postgres 11 version which is default for bitnami chart