### PR TITLE
Explicitly specify encoding

### DIFF
--- a/octopod-frontend/index.html
+++ b/octopod-frontend/index.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+  <meta charset="UTF-8">
 </head>
 
 <body>


### PR DESCRIPTION
After deploying version 1.2 the frontend stopped working with the following errors:

![Screenshot 2021-07-16 at 19 18 01](https://user-images.githubusercontent.com/6209627/125978367-fceff7dc-1325-4646-9520-c63d19c16c0b.png)


I think we might have changed the nginx configuration at some point and it stopped returning the encoding. Adding it explicitly to the HTML should help.