### PR TITLE
Fixed override issue on frontend

### DIFF
--- a/dev/dev_backend.sh
+++ b/dev/dev_backend.sh
@@ -25,7 +25,4 @@ $1/bin/octopod-exe \
     --ui-port 3002 \
     --ws-port 4020 \
     --db "host='127.0.0.1' port=5432 user='octopod' password='octopod'" \
-    --db-pool-size 10 \
-    --tls-cert-path dev/certs/server_cert.pem \
-    --tls-key-path dev/certs/server_key.pem \
-    --tls-store-path /tmp/tls_store
+    --db-pool-size 10

--- a/dev/fail.sh
+++ b/dev/fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exit 1

--- a/octopod-frontend/src/Page/Popup/EditDeployment.hs
+++ b/octopod-frontend/src/Page/Popup/EditDeployment.hs
@@ -98,8 +98,8 @@ editDeploymentPopupBody dfi errEv = divClass "popup__content" $
     let
       oldAppVarDyn = coerce <$> getOldVars dfiAppVars <$> appVarsDyn
       newAppVarDyn = coerce <$> getNewVars dfiAppVars <$> appVarsDyn
-      oldDeploymentVarDyn = coerce <$> getOldVars dfiAppVars <$> deploymentVarsDyn
-      newDeploymentVarDyn = coerce <$> getNewVars dfiAppVars <$> deploymentVarsDyn
+      oldDeploymentVarDyn = coerce <$> getOldVars dfiDeploymentVars <$> deploymentVarsDyn
+      newDeploymentVarDyn = coerce <$> getNewVars dfiDeploymentVars <$> deploymentVarsDyn
     validDyn <- holdDyn True $ updated tOkEv
     pure $ (DeploymentUpdate
       <$> (DeploymentTag <$> tagDyn)


### PR DESCRIPTION
Previously you could not delete deployment overrides because of a bug in frontend code. This issue could also delete deployment overrides when you wanted to delete an application override. 

This should now be fixed.