### PR TITLE
Resolved metadata event passthrough issue

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
   "haskell.plugin.hlint.diagnosticsOn": false,
   "haskell.hlint.logLevel": "none",
   "haskell.hlint.run": "never",
-  "haskell.serverExecutablePath": "haskell-language-server"
+  "haskell.serverExecutablePath": "haskell-language-server",
+  "editor.formatOnSave": true
 }

--- a/octopod-frontend/src/Frontend/UIKit/Button/Action.hs
+++ b/octopod-frontend/src/Frontend/UIKit/Button/Action.hs
@@ -18,7 +18,7 @@ data ActionButtonConfig t = ActionButtonConfig
   { buttonText :: Text
   , buttonEnabled :: Dynamic t Bool
   , buttonType :: Maybe ActionButtonType
-  , buttonBaseTag :: BaseButtonTag
+  , buttonBaseTag :: BaseButtonTag t
   }
   deriving stock (Generic)
 

--- a/octopod-frontend/src/Frontend/UIKit/Button/Large.hs
+++ b/octopod-frontend/src/Frontend/UIKit/Button/Large.hs
@@ -23,7 +23,7 @@ data LargeButtonConfig t = LargeButtonConfig
   , buttonType :: Dynamic t (Maybe LargeButtonType)
   , buttonPriority :: LargeButtonPriority
   , buttonStyle :: LargeButtonStyle
-  , buttonBaseTag :: BaseButtonTag
+  , buttonBaseTag :: BaseButtonTag t
   }
   deriving stock (Generic)
 

--- a/octopod-frontend/src/Page/Deployment.hs
+++ b/octopod-frontend/src/Page/Deployment.hs
@@ -158,7 +158,7 @@ deploymentHead dfiDyn sentEv =
                     , buttonType = pure $ Just LogsLargeButtonType
                     , buttonPriority = SecondaryLargeButton
                     , buttonStyle = PageActionLargeButtonStyle
-                    , buttonBaseTag = ATag url
+                    , buttonBaseTag = ATag $ pure url
                     }
           )
     delEv <- confirmArchivePopup (archEv $> ()) $ do

--- a/octopod-frontend/src/Page/Deployments.hs
+++ b/octopod-frontend/src/Page/Deployments.hs
@@ -295,7 +295,7 @@ activeDeploymentWidget dDyn' = do
                               def
                                 { buttonText = "Details"
                                 , buttonType = Just LogsActionButtonType
-                                , buttonBaseTag = ATag url
+                                , buttonBaseTag = ATag $ pure url
                                 }
                       )
                 pure $
@@ -379,7 +379,7 @@ archivedDeploymentWidget dDyn' = do
           btnEv <- dropdownWidget body
           void $ restoreEndpoint (constDyn $ Right $ dName) (btnEv $> ())
       let route = DashboardRoute :/ Just dName
-      setRoute $ route <$ domEvent Dblclick linkEl
+      setRoute $ route <$ domEvent Click linkEl
 
 -- | Sort deployments by the supplied condition.
 sortDeployments ::

--- a/octopod-frontend/src/Page/Elements/Links.hs
+++ b/octopod-frontend/src/Page/Elements/Links.hs
@@ -4,8 +4,11 @@ module Page.Elements.Links
 where
 
 import Common.Types
+import Common.Utils ((<^.>))
 import Control.Lens
+import Control.Monad
 import qualified Data.Text as T
+import Frontend.UIKit.Button.Common
 import Reflex.Dom
 
 renderMetadataLink ::
@@ -13,14 +16,20 @@ renderMetadataLink ::
   Dynamic t DeploymentMetadatum ->
   m ()
 renderMetadataLink metadataD = do
-  let attrDyn =
-        metadataD <&> \metadata ->
-          "class" =: "listing__item external bar bar--larger"
-            <> "href" =: metadata ^. #link
-            <> "target" =: "_blank"
-  elDynAttr "a" attrDyn . dynText $
-    metadataD <&> \case
-      -- If the name is empty, then use the url
-      DeploymentMetadatum {name = name}
-        | (not . T.null . T.strip) name -> name
-      DeploymentMetadatum {link = url} -> url
+  void $
+    buttonEl
+      CommonButtonConfig
+        { constantClasses = pure $ "listing__item" <> "external" <> "bar" <> "bar--larger"
+        , enabledClasses = mempty
+        , disabledClasses = "button--disabled"
+        , buttonEnabled = pure True
+        , buttonText =
+            TextBuilder $
+              dynText $
+                metadataD <&> \case
+                  -- If the name is empty, then use the url
+                  DeploymentMetadatum {name = name}
+                    | (not . T.null . T.strip) name -> name
+                  DeploymentMetadatum {link = url} -> url
+        , buttonBaseTag = ATag $ metadataD <^.> #link
+        }


### PR DESCRIPTION
Fixes a bug where clicking a metadata link on the deployments table opens the deployment.